### PR TITLE
use recurselimit to avoid managing too many files under crypt_directory

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,12 +29,13 @@ class crypt::install {
   }
 
   file { $crypt_directory:
-    ensure  => directory,
-    owner   => 0,
-    group   => 0,
-    mode    => '0755',
-    recurse => true,
-    require => Apple_package['Crypt']
+    ensure       => directory,
+    owner        => 0,
+    group        => 0,
+    mode         => '0755',
+    recurse      => true,
+    recurselimit => 1,
+    require      => Apple_package['Crypt']
   }
 
   $plist = {


### PR DESCRIPTION
There are almost 5000 more files under /Library/Crypt in Crypt 4.0 compared to the previous version, and we should limit the recursion depth to avoid Puppet managing too many resources which slow down the Puppet applying speed.